### PR TITLE
Fix constructor deprecation warning

### DIFF
--- a/ucam_webauth.php
+++ b/ucam_webauth.php
@@ -98,7 +98,7 @@ class Ucam_Webauth {
 			     '560' => 'Web server not authorized to use the authentication service',
 			     '570' => 'Operation declined by the authentication service');
 
-  function Ucam_Webauth($args) {
+  function __construct($args) {
     if (isset($args['auth_service'])) $this->auth_service = $args['auth_service'];
     else $this->auth_service = $this->DEFAULT_AUTH_SERVICE;
 


### PR DESCRIPTION
Constructors should now (since PHP 5) be 'function __construct(...)', not
'function <class_name>(...)'